### PR TITLE
Add a bloopInstall profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -611,6 +611,7 @@
                             <execution>
                                 <id>generate-bloop-projects</id>
                                 <goals><goal>bloopInstall</goal></goals>
+                                <phase>${bloopInstallPhase}</phase>
                             </execution>
                         </executions>
                     </plugin>
@@ -814,6 +815,7 @@
             -Djdk.reflect.useDirectMethodHandle=false
         </extraJavaTestArgs>
         <cloudera.repo.enabled>false</cloudera.repo.enabled>
+        <bloopInstallPhase>install</bloopInstallPhase>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -569,6 +569,9 @@
                 <jni.classifier>${cuda.version}-arm64</jni.classifier>
             </properties>
         </profile>
+        <profile>
+            <id>bloopInstall</id>
+        </profile>
     </profiles>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -571,6 +571,12 @@
         </profile>
         <profile>
             <id>bloopInstall</id>
+            <activation>
+                <property>
+                    <name>bloopInstall</name>
+                    <value>true</value>
+                </property>
+            </activation>
             <properties>
                 <!-- Metals looks at the repo root. so to accomodate scala 2.13  define -->
                 <bloop.configDirectory>${spark.rapids.source.basedir}/.bloop</bloop.configDirectory>
@@ -618,19 +624,11 @@
     <properties>
         <rapids.module>.</rapids.module>
         <allowConventionalDistJar>false</allowConventionalDistJar>
-        <maven.scaladoc.skip>false</maven.scaladoc.skip>
-        <!-- #if scala-2.12 -->
         <buildver>311</buildver>
-        <spark.version>${spark311.version}</spark.version>
-        <!-- #endif scala-2.12 -->
-        <!-- #if scala-2.13 --><!--
-        <buildver>330</buildver>
-        <spark.version>${spark330.version}</spark.version>
-        --><!-- #endif scala-2.13 -->
-
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <java.major.version>8</java.major.version>
+        <spark.version>${spark311.version}</spark.version>
         <spark.test.version>${spark.version}</spark.test.version>
         <parquet.hadoop.version>1.10.1</parquet.hadoop.version>
         <spark.version.classifier>spark${buildver}</spark.version.classifier>
@@ -707,6 +705,7 @@
         <scala.local-lib.path>org/scala-lang/scala-library/${scala.version}/scala-library-${scala.version}.jar</scala.local-lib.path>
         <target.classifier>${spark.version.classifier}</target.classifier>
         <maven.clean.plugin.version>3.1.0</maven.clean.plugin.version>
+        <maven.scaladoc.skip>false</maven.scaladoc.skip>
         <maven.scalastyle.skip>false</maven.scalastyle.skip>
         <dist.jar.compress>true</dist.jar.compress>
         <spark330.iceberg.version>0.14.1</spark330.iceberg.version>

--- a/pom.xml
+++ b/pom.xml
@@ -574,6 +574,9 @@
             <properties>
                 <!-- Metals looks at the repo root. so to accomodate scala 2.13  define -->
                 <bloop.configDirectory>${spark.rapids.source.basedir}/.bloop</bloop.configDirectory>
+                <skipTests>true</skipTests>
+                <maven.scaladoc.skip>true</maven.scaladoc.skip>
+                <maven.scalastyle.skip>true</maven.scalastyle.skip>
             </properties>
             <build>
                 <plugins>
@@ -596,13 +599,9 @@
                         </executions>
                     </plugin>
                     <plugin>
-                        <!-- make sure bloop execution is after install plugin -->
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-install-plugin</artifactId>
-                    </plugin>
-                    <plugin>
                         <groupId>ch.epfl.scala</groupId>
                         <artifactId>bloop-maven-plugin</artifactId>
+                        <version>2.0.0</version>
                         <executions>
                             <execution>
                                 <id>generate-bloop-projects</id>
@@ -619,6 +618,7 @@
     <properties>
         <rapids.module>.</rapids.module>
         <allowConventionalDistJar>false</allowConventionalDistJar>
+        <maven.scaladoc.skip>false</maven.scaladoc.skip>
         <!-- #if scala-2.12 -->
         <buildver>311</buildver>
         <spark.version>${spark311.version}</spark.version>
@@ -1095,6 +1095,7 @@
                                     <arg>-doc-external-doc:${settings.localRepository}/${scala.local-lib.path}#https://scala-lang.org/api/${scala.version}/</arg>
                                     <arg>-doc-external-doc:${settings.localRepository}/org/apache/spark/spark-sql_${scala.binary.version}/${spark.version}/spark-sql_${scala.binary.version}-${spark.version}.jar#https://spark.apache.org/docs/${spark.version}/api/scala/index.html</arg>
                                 </args>
+                                <skip>${maven.scaladoc.skip}</skip>
                             </configuration>
                         </execution>
                     </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -571,17 +571,66 @@
         </profile>
         <profile>
             <id>bloopInstall</id>
+            <properties>
+                <!-- Metals looks at the repo root. so to accomodate scala 2.13  define -->
+                <bloop.configDirectory>${spark.rapids.source.basedir}/.bloop</bloop.configDirectory>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>enforce-bloop-rules</id>
+                                <goals><goal>enforce</goal></goals>
+                                <configuration>
+                                    <rules>
+                                        <requireJavaVersion>
+                                            <message>Metals semanic database requires JAVA_HOME pointinting to JDK 11+, actual Java version: ${java.version}</message>
+                                            <version>[11,)</version>
+                                        </requireJavaVersion>
+                                    </rules>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <!-- make sure bloop execution is after install plugin -->
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-install-plugin</artifactId>
+                    </plugin>
+                    <plugin>
+                        <groupId>ch.epfl.scala</groupId>
+                        <artifactId>bloop-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>generate-bloop-projects</id>
+                                <goals><goal>bloopInstall</goal></goals>
+                                <phase>install</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 
     <properties>
         <rapids.module>.</rapids.module>
         <allowConventionalDistJar>false</allowConventionalDistJar>
+        <!-- #if scala-2.12 -->
         <buildver>311</buildver>
+        <spark.version>${spark311.version}</spark.version>
+        <!-- #endif scala-2.12 -->
+        <!-- #if scala-2.13 --><!--
+        <buildver>330</buildver>
+        <spark.version>${spark330.version}</spark.version>
+        --><!-- #endif scala-2.13 -->
+
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <java.major.version>8</java.major.version>
-        <spark.version>${spark311.version}</spark.version>
         <spark.test.version>${spark.version}</spark.test.version>
         <parquet.hadoop.version>1.10.1</parquet.hadoop.version>
         <spark.version.classifier>spark${buildver}</spark.version.classifier>

--- a/pom.xml
+++ b/pom.xml
@@ -607,12 +607,10 @@
                     <plugin>
                         <groupId>ch.epfl.scala</groupId>
                         <artifactId>bloop-maven-plugin</artifactId>
-                        <version>2.0.0</version>
                         <executions>
                             <execution>
                                 <id>generate-bloop-projects</id>
                                 <goals><goal>bloopInstall</goal></goals>
-                                <phase>install</phase>
                             </execution>
                         </executions>
                     </plugin>
@@ -1264,6 +1262,21 @@
         </pluginManagement>
 
         <plugins>
+            <plugin>
+                <groupId>ch.epfl.scala</groupId>
+                <artifactId>bloop-maven-plugin</artifactId>
+                <version>2.0.0</version>
+                <executions>
+                    <execution>
+                        <id>default-cli</id>
+                        <configuration>
+                            <skip>true</skip>
+                            <!-- workaround: skip is not skipping -->
+                            <bloopConfigDir>/dev/null/ERROR: Do not specify the bloop-maven-plugin on the command line. Instead invoke `mvn install -DbloopInstall ...`</bloopConfigDir>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -578,8 +578,6 @@
                 </property>
             </activation>
             <properties>
-                <!-- Metals looks at the repo root. so to accomodate scala 2.13  define -->
-                <bloop.configDirectory>${spark.rapids.source.basedir}/.bloop</bloop.configDirectory>
                 <skipTests>true</skipTests>
                 <maven.scaladoc.skip>true</maven.scaladoc.skip>
                 <maven.scalastyle.skip>true</maven.scalastyle.skip>
@@ -612,6 +610,10 @@
                                 <id>generate-bloop-projects</id>
                                 <goals><goal>bloopInstall</goal></goals>
                                 <phase>${bloopInstallPhase}</phase>
+                                <configuration>
+                                    <!-- Metals looks at the repo root. so to accomodate scala 2.13  define -->
+                                    <bloopConfigDir>${spark.rapids.source.basedir}/.bloop</bloopConfigDir>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -596,7 +596,7 @@
                                 <configuration>
                                     <rules>
                                         <requireJavaVersion>
-                                            <message>Metals semanic database requires JAVA_HOME pointinting to JDK 11+, actual Java version: ${java.version}</message>
+                                            <message>Metals semantic database requires JAVA_HOME pointing to JDK 11+, actual Java version: ${java.version}</message>
                                             <version>[11,)</version>
                                         </requireJavaVersion>
                                     </rules>

--- a/scala2.13/pom.xml
+++ b/scala2.13/pom.xml
@@ -596,7 +596,7 @@
                                 <configuration>
                                     <rules>
                                         <requireJavaVersion>
-                                            <message>Metals semanic database requires JAVA_HOME pointinting to JDK 11+, actual Java version: ${java.version}</message>
+                                            <message>Metals semantic database requires JAVA_HOME pointing to JDK 11+, actual Java version: ${java.version}</message>
                                             <version>[11,)</version>
                                         </requireJavaVersion>
                                     </rules>
@@ -607,12 +607,10 @@
                     <plugin>
                         <groupId>ch.epfl.scala</groupId>
                         <artifactId>bloop-maven-plugin</artifactId>
-                        <version>2.0.0</version>
                         <executions>
                             <execution>
                                 <id>generate-bloop-projects</id>
                                 <goals><goal>bloopInstall</goal></goals>
-                                <phase>install</phase>
                             </execution>
                         </executions>
                     </plugin>
@@ -1264,6 +1262,21 @@
         </pluginManagement>
 
         <plugins>
+            <plugin>
+                <groupId>ch.epfl.scala</groupId>
+                <artifactId>bloop-maven-plugin</artifactId>
+                <version>2.0.0</version>
+                <executions>
+                    <execution>
+                        <id>default-cli</id>
+                        <configuration>
+                            <skip>true</skip>
+                            <!-- workaround: skip is not skipping -->
+                            <bloopConfigDir>/dev/null/ERROR: Do not specify the bloop-maven-plugin on the command line. Instead invoke `mvn install -DbloopInstall ...`</bloopConfigDir>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>

--- a/scala2.13/pom.xml
+++ b/scala2.13/pom.xml
@@ -596,6 +596,7 @@
                         </executions>
                     </plugin>
                     <plugin>
+                        <!-- make sure bloop execution is after install plugin -->
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-install-plugin</artifactId>
                     </plugin>

--- a/scala2.13/pom.xml
+++ b/scala2.13/pom.xml
@@ -611,6 +611,7 @@
                             <execution>
                                 <id>generate-bloop-projects</id>
                                 <goals><goal>bloopInstall</goal></goals>
+                                <phase>${bloopInstallPhase}</phase>
                             </execution>
                         </executions>
                     </plugin>
@@ -814,6 +815,7 @@
             -Djdk.reflect.useDirectMethodHandle=false
         </extraJavaTestArgs>
         <cloudera.repo.enabled>false</cloudera.repo.enabled>
+        <bloopInstallPhase>install</bloopInstallPhase>
     </properties>
 
     <dependencyManagement>

--- a/scala2.13/pom.xml
+++ b/scala2.13/pom.xml
@@ -574,6 +574,9 @@
             <properties>
                 <!-- Metals looks at the repo root. so to accomodate scala 2.13  define -->
                 <bloop.configDirectory>${spark.rapids.source.basedir}/.bloop</bloop.configDirectory>
+                <skipTests>true</skipTests>
+                <maven.scaladoc.skip>true</maven.scaladoc.skip>
+                <maven.scalastyle.skip>true</maven.scalastyle.skip>
             </properties>
             <build>
                 <plugins>
@@ -596,13 +599,9 @@
                         </executions>
                     </plugin>
                     <plugin>
-                        <!-- make sure bloop execution is after install plugin -->
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-install-plugin</artifactId>
-                    </plugin>
-                    <plugin>
                         <groupId>ch.epfl.scala</groupId>
                         <artifactId>bloop-maven-plugin</artifactId>
+                        <version>2.0.0</version>
                         <executions>
                             <execution>
                                 <id>generate-bloop-projects</id>
@@ -619,6 +618,7 @@
     <properties>
         <rapids.module>.</rapids.module>
         <allowConventionalDistJar>false</allowConventionalDistJar>
+        <maven.scaladoc.skip>false</maven.scaladoc.skip>
         <!-- #if scala-2.12 --><!--
         <buildver>311</buildver>
         <spark.version>${spark311.version}</spark.version>
@@ -1095,6 +1095,7 @@
                                     <arg>-doc-external-doc:${settings.localRepository}/${scala.local-lib.path}#https://scala-lang.org/api/${scala.version}/</arg>
                                     <arg>-doc-external-doc:${settings.localRepository}/org/apache/spark/spark-sql_${scala.binary.version}/${spark.version}/spark-sql_${scala.binary.version}-${spark.version}.jar#https://spark.apache.org/docs/${spark.version}/api/scala/index.html</arg>
                                 </args>
+                                <skip>${maven.scaladoc.skip}</skip>
                             </configuration>
                         </execution>
                     </executions>

--- a/scala2.13/pom.xml
+++ b/scala2.13/pom.xml
@@ -569,6 +569,9 @@
                 <jni.classifier>${cuda.version}-arm64</jni.classifier>
             </properties>
         </profile>
+        <profile>
+            <id>bloopInstall</id>
+        </profile>
     </profiles>
 
     <properties>

--- a/scala2.13/pom.xml
+++ b/scala2.13/pom.xml
@@ -571,6 +571,12 @@
         </profile>
         <profile>
             <id>bloopInstall</id>
+            <activation>
+                <property>
+                    <name>bloopInstall</name>
+                    <value>true</value>
+                </property>
+            </activation>
             <properties>
                 <!-- Metals looks at the repo root. so to accomodate scala 2.13  define -->
                 <bloop.configDirectory>${spark.rapids.source.basedir}/.bloop</bloop.configDirectory>
@@ -618,19 +624,11 @@
     <properties>
         <rapids.module>.</rapids.module>
         <allowConventionalDistJar>false</allowConventionalDistJar>
-        <maven.scaladoc.skip>false</maven.scaladoc.skip>
-        <!-- #if scala-2.12 --><!--
         <buildver>311</buildver>
-        <spark.version>${spark311.version}</spark.version>
-        --><!-- #endif scala-2.12 -->
-        <!-- #if scala-2.13 -->
-        <buildver>330</buildver>
-        <spark.version>${spark330.version}</spark.version>
-        <!-- #endif scala-2.13 -->
-
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <java.major.version>8</java.major.version>
+        <spark.version>${spark330.version}</spark.version>
         <spark.test.version>${spark.version}</spark.test.version>
         <parquet.hadoop.version>1.10.1</parquet.hadoop.version>
         <spark.version.classifier>spark${buildver}</spark.version.classifier>
@@ -707,6 +705,7 @@
         <scala.local-lib.path>org/scala-lang/scala-library/${scala.version}/scala-library-${scala.version}.jar</scala.local-lib.path>
         <target.classifier>${spark.version.classifier}</target.classifier>
         <maven.clean.plugin.version>3.1.0</maven.clean.plugin.version>
+        <maven.scaladoc.skip>false</maven.scaladoc.skip>
         <maven.scalastyle.skip>false</maven.scalastyle.skip>
         <dist.jar.compress>true</dist.jar.compress>
         <spark330.iceberg.version>0.14.1</spark330.iceberg.version>

--- a/scala2.13/pom.xml
+++ b/scala2.13/pom.xml
@@ -578,8 +578,6 @@
                 </property>
             </activation>
             <properties>
-                <!-- Metals looks at the repo root. so to accomodate scala 2.13  define -->
-                <bloop.configDirectory>${spark.rapids.source.basedir}/.bloop</bloop.configDirectory>
                 <skipTests>true</skipTests>
                 <maven.scaladoc.skip>true</maven.scaladoc.skip>
                 <maven.scalastyle.skip>true</maven.scalastyle.skip>
@@ -612,6 +610,10 @@
                                 <id>generate-bloop-projects</id>
                                 <goals><goal>bloopInstall</goal></goals>
                                 <phase>${bloopInstallPhase}</phase>
+                                <configuration>
+                                    <!-- Metals looks at the repo root. so to accomodate scala 2.13  define -->
+                                    <bloopConfigDir>${spark.rapids.source.basedir}/.bloop</bloopConfigDir>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>

--- a/scala2.13/pom.xml
+++ b/scala2.13/pom.xml
@@ -571,17 +571,65 @@
         </profile>
         <profile>
             <id>bloopInstall</id>
+            <properties>
+                <!-- Metals looks at the repo root. so to accomodate scala 2.13  define -->
+                <bloop.configDirectory>${spark.rapids.source.basedir}/.bloop</bloop.configDirectory>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>enforce-bloop-rules</id>
+                                <goals><goal>enforce</goal></goals>
+                                <configuration>
+                                    <rules>
+                                        <requireJavaVersion>
+                                            <message>Metals semanic database requires JAVA_HOME pointinting to JDK 11+, actual Java version: ${java.version}</message>
+                                            <version>[11,)</version>
+                                        </requireJavaVersion>
+                                    </rules>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-install-plugin</artifactId>
+                    </plugin>
+                    <plugin>
+                        <groupId>ch.epfl.scala</groupId>
+                        <artifactId>bloop-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>generate-bloop-projects</id>
+                                <goals><goal>bloopInstall</goal></goals>
+                                <phase>install</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 
     <properties>
         <rapids.module>.</rapids.module>
         <allowConventionalDistJar>false</allowConventionalDistJar>
+        <!-- #if scala-2.12 --><!--
         <buildver>311</buildver>
+        <spark.version>${spark311.version}</spark.version>
+        --><!-- #endif scala-2.12 -->
+        <!-- #if scala-2.13 -->
+        <buildver>330</buildver>
+        <spark.version>${spark330.version}</spark.version>
+        <!-- #endif scala-2.13 -->
+
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <java.major.version>8</java.major.version>
-        <spark.version>${spark330.version}</spark.version>
         <spark.test.version>${spark.version}</spark.test.version>
         <parquet.hadoop.version>1.10.1</parquet.hadoop.version>
         <spark.version.classifier>spark${buildver}</spark.version.classifier>


### PR DESCRIPTION
This is a suggestion for your PR NVIDIA/spark-rapids#9615 

We can simplify Maven command for the bloop project generation by creating a bloopInstall profile

`mvn [-f scala2.13] install -B -Dmaven.repo.local=$PWD/.bloop-m2 -DbloopInstall -Dbuildver=3XY`, and enforce Java11+ there.

Running bloopInstall plugin on the command line is prevented by specifying an invalid config path.

```
mvn -f scala2.13 -Dmaven.repo.local=$PWD/.bloop-m2 -Dbuildver=330 ch.epfl.scala:bloop-maven-plugin:bloopInstall
...
[ERROR] /dev/null/ERROR: Do not specify the bloop-maven-plugin on the command line. Instead invoke `mvn install -DbloopInstall ...`: Not a directory
```


We can change buildall and doc accordingly.